### PR TITLE
Fix: del_put_thunk gets wrong flag thunk position

### DIFF
--- a/libasmir/src/irtoir.cpp
+++ b/libasmir/src/irtoir.cpp
@@ -423,11 +423,8 @@ int del_put_thunk(vector<Stmt *> *ir, string mnemonic, int opi, int dep1, int de
                         len--;
                     }                    
 
-                    if (ret == -1)
-                    {
-                        // remember flag thunks position
-                        ret = len;
-                    }    
+		    // remember flag last thunk position
+                    ret = len;
                 }
             }
         }


### PR DESCRIPTION
For example, `cmp dl, al`has two cast instructions in a eflags modification, the correct position to insert eflags mod should be at the last thunk(not the first) so that the two cast instructions will be placed in front of eflags mod, not behind.

Before handle eflags modification
```
BIN { 00000000: 38 c2 }
ASM { 00000000: cmp dl, al ; len = 2 }
BAP {
   label pc_0x0:
   var T_8t0:reg8_t;
   var T_8t1:reg8_t;
   var T_8t2:reg8_t;
   var T_32t3:reg32_t;
   var T_32t4:reg32_t;
   var T_32t5:reg32_t;
   T_8t2:reg8_t = cast(R_EDX:reg32_t)L:reg8_t;
   T_8t1:reg8_t = cast(R_EAX:reg32_t)L:reg8_t;
   // NoOp
   R_CC_OP:reg32_t = 4:reg32_t;
   T_32t3:reg32_t = cast(T_8t2:reg8_t)U:reg32_t;
   R_CC_DEP1:reg32_t = T_32t3:reg32_t;
   T_32t4:reg32_t = cast(T_8t1:reg8_t)U:reg32_t;
   R_CC_DEP2:reg32_t = T_32t4:reg32_t;
   R_CC_NDEP:reg32_t = 0:reg32_t;
   // BAP label pc_0x0 at 00000000.00
00000000.00     AND         R_EDX:32,            ff:32,           V_00:8  
00000000.01     AND         R_EAX:32,            ff:32,           V_01:8  
00000000.02     STR             4:32,                 ,       R_CC_OP:32  
00000000.03      OR           V_00:8,              0:8,          V_02:32  
00000000.04     STR          V_02:32,                 ,     R_CC_DEP1:32  
00000000.05      OR           V_01:8,              0:8,          V_03:32  
00000000.06     STR          V_03:32,                 ,     R_CC_DEP2:32  
00000000.07     STR             0:32,                 ,     R_CC_NDEP:32  
}
```

Before fix
```
// NoOp
// eflags thunk: sub
var T_0:reg32_t;
T_0:reg32_t = ((T_32t3:reg32_t-T_32t4:reg32_t)&255:reg32_t);
... //eflags mod
T_32t3:reg32_t = cast(T_8t2:reg8_t)U:reg32_t;
T_32t4:reg32_t = cast(T_8t1:reg8_t)U:reg32_t;
```

After fix
```
// NoOp
T_32t3:reg32_t = cast(T_8t2:reg8_t)U:reg32_t;
T_32t4:reg32_t = cast(T_8t1:reg8_t)U:reg32_t;
// eflags thunk: sub
var T_0:reg32_t;
T_0:reg32_t = ((T_32t3:reg32_t-T_32t4:reg32_t)&255:reg32_t);
```