### PR TITLE
Fix clearing 'errno' before calling 'strtoll()'

### DIFF
--- a/libopenreil/src/reil_translator.cpp
+++ b/libopenreil/src/reil_translator.cpp
@@ -1512,6 +1512,7 @@ bool CReilFromBilTranslator::get_bil_label(string name, reil_addr_t *addr)
     if (!strncmp(c_name, "pc_0x", 5))
     {
         // get code pointer from label text
+        errno = 0;
         ret = strtoll(c_name + 5, NULL, 16);
         reil_assert(errno != EINVAL, "invalid pc value");
 


### PR DESCRIPTION
After translating a BIL label, it is possible to throw an exception that isn't valid. After the call to ```strtoll()```, ```reil_assert()``` is used to make sure an invalid parameter hasn't been passed to the ```strtoll()``` function by checking the value of ```errno```. The problem is, it seems that some other function is actually setting ```errno == EINVAL``` other than ```strtoll()``` and as a result, a valid label conversion may fail.

I only experienced this after running a large number of translations through OpenREIL in a single process/handle instance, but haven't pinned down the exact cause. The fix is to reset ```errno``` before the call to ```strtoll()```. This fixes my issues and I don't get ```invalid pc value``` exceptions during my PIN Tool's dynamic translation runs. 

This small pull request clears ```errno``` before calling ```strtoll()``` to explicitly ensure ```strtoll()``` is the guilty function when checking for an error in the following ```reil_assert()``` sanity check.