### PR TITLE
Fix(Code): 'Set target architecture'

### DIFF
--- a/libopenreil/apps/translate-inst.cpp
+++ b/libopenreil/apps/translate-inst.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
         printf("[+] Using ARM architecture\n");
 
         // set target architecture
-        arch = ARCH_X86;
+        arch = ARCH_ARM;
     }
     else
     {


### PR DESCRIPTION
I think you did mean this code.

Architecture name is mismatch.

The original code was assign x86 to arch variable when architecture name was arm.