### PR TITLE
Modify README.md about processing 'make test'

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ $ make test
 $ sudo make install
 ```
 
+Exception!
+If you have error in make test, Install the GCC, G++ cross compilers and support programs by typing 
+```
+$ sudo apt-get install libc6-armel-cross libc6-dev-armel-cross
+$ sudo apt-get install binutils-arm-linux-gnueabi
+$ sudo apt-get install libncurses5-dev
+```
+
 If you planning to use [MongoDB](http://www.mongodb.org/) as IR code storage you need to install some additional dependencies:
 
 ```


### PR DESCRIPTION
I got an error in 'make test'.
The reason for the error was that the CROSS COMPILER was not installed.
So, I think that you need a description of the installation of cross compiler in README.