### PR TITLE
modify README.md about processing './autogen.sh'

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ $ make
 $ make test
 $ sudo make install
 ```
+Exception!
+If you have error in ./autogen.sh, Install autoconf
+```
+$ sudo apt-get install autoconf
+```
+
 
 If you planning to use [MongoDB](http://www.mongodb.org/) as IR code storage you need to install some additional dependencies:
 


### PR DESCRIPTION
I got an error in './autogen.sh'.
The reason for the error was that the autoconf was not installed.
So, I think that you need a description of the installation of autoconf README.